### PR TITLE
Update to 0.8.1170

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	<upstreamVersion>0.8.1170</upstreamVersion>
+        <upstreamVersion>0.8.1170</upstreamVersion>
         <upstreamBuild>c132a99</upstreamBuild>
         <sourceUrl>https://github.com/mozilla/pdf.js/tarball</sourceUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>


### PR DESCRIPTION
Since there is no official release and no git tag, i have switched build using make.js version and git commit id.

I also excluded 'test' folder because it's a huge folder.
